### PR TITLE
ACC-1169 main branch name change chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -154,7 +154,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node: &container_config_lambda_node
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -109,7 +109,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ toolsets to create javascript function enhancers ([decorators](https://hackernoo
 
 
 [![CircleCI](https://circleci.com/gh/Financial-Times/n-express-enhancer.svg?style=shield)](https://circleci.com/gh/Financial-Times/n-express-enhancer)
-[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-express-enhancer/badge.svg?branch=master)](https://coveralls.io/github/Financial-Times/n-express-enhancer?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-express-enhancer/badge.svg?branch=main)](https://coveralls.io/github/Financial-Times/n-express-enhancer?branch=main)
 [![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/n-express-enhancer/badge.svg)](https://snyk.io/test/github/Financial-Times/n-express-enhancer)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-express-enhancer/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Financial-Times/n-express-enhancer/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-express-enhancer/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/Financial-Times/n-express-enhancer/?branch=main)
 [![Dependencies](https://david-dm.org/Financial-Times/n-express-enhancer.svg)](https://david-dm.org/Financial-Times/n-express-enhancer)
 [![devDependencies](https://david-dm.org/Financial-Times/n-express-enhancer/dev-status.svg)](https://david-dm.org/Financial-Times/n-express-enhancer?type=dev)
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "supertest": "^3.1.0"
   },
   "engines": {
-    "node": ">=6.10"
+    "node": "12.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,16 +10,13 @@
     "test": "jest",
     "cover": "jest --coverage",
     "prepublish": "make build",
-    "precommit": "node_modules/.bin/secret-squirrel",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make lint unit-test && make verify -j3",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "compose-function": "^3.0.3"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^3.6.0",
+    "@financial-times/n-gage": "^8.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
@@ -45,5 +42,12 @@
   },
   "engines": {
     "node": "12.x"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-push": "make lint unit-test && make verify -j3"
+    }
   }
 }

--- a/src/__tests__/create-enhancer.js
+++ b/src/__tests__/create-enhancer.js
@@ -75,18 +75,12 @@ describe('createEnhancer can create enhancer', () => {
 		it('when enhance non-async function', () => {
 			const enhancerA = createMockEnhancer('enhancerA');
 			const enhancerB = createMockEnhancer('enhancerB');
-			const enhanced = compose(
-				enhancerA,
-				enhancerB,
-			)(targetFunction);
+			const enhanced = compose(enhancerA, enhancerB)(targetFunction);
 			const result = enhanced(initArg);
 			expect(callOrderFunction.mock.calls).toMatchSnapshot();
 			expect(result).toMatchSnapshot();
 			jest.clearAllMocks();
-			const reverseEnhanced = compose(
-				enhancerB,
-				enhancerA,
-			)(targetFunction);
+			const reverseEnhanced = compose(enhancerB, enhancerA)(targetFunction);
 			const reverseResult = reverseEnhanced(initArg);
 			expect(callOrderFunction.mock.calls).toMatchSnapshot();
 			expect(reverseResult).toMatchSnapshot();
@@ -95,18 +89,12 @@ describe('createEnhancer can create enhancer', () => {
 		it('when enhance async function', async () => {
 			const enhancerA = createMockEnhancer('enhancerA');
 			const enhancerB = createMockEnhancer('enhancerB');
-			const enhanced = compose(
-				enhancerA,
-				enhancerB,
-			)(asyncTargetFunction);
+			const enhanced = compose(enhancerA, enhancerB)(asyncTargetFunction);
 			const result = await enhanced(initArg);
 			expect(callOrderFunction.mock.calls).toMatchSnapshot();
 			expect(result).toMatchSnapshot();
 			jest.clearAllMocks();
-			const reverseEnhanced = compose(
-				enhancerB,
-				enhancerA,
-			)(targetFunction);
+			const reverseEnhanced = compose(enhancerB, enhancerA)(targetFunction);
 			const reverseResult = await reverseEnhanced(initArg);
 			expect(callOrderFunction.mock.calls).toMatchSnapshot();
 			expect(reverseResult).toMatchSnapshot();


### PR DESCRIPTION
**Description**
Following the branch name change, this PR handles associated chores as per https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master)
- upgrades n-gage
- updates CI yaml to use the new name
- updates links
- bumps up node version in package.json to 12
- bumps up node version in CI docker images to 12
- closes #12 

**Ticket**
https://financialtimes.atlassian.net/browse/ACC-1169

**We're bumping how many n-gage versions?!**
TOO MANY. But I think none of those changes affect this repo.
v8.0.0 - the package-lock.json change is opt in https://github.com/Financial-Times/n-gage/releases/tag/v8.0.0
v7.0.0 - is an upgrade to Node v12 https://github.com/Financial-Times/n-gage/releases/tag/v7.0.0
v6.0.0 - something to do with asset-hashes.json, action only needed if this file is present in the project
v5.0.0 - updates Husky format. Staging smoke tests now run on https
v4.0.0 - removes all n-ui related code